### PR TITLE
chore: add pytest, python, and uv to Claude allowed commands

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,13 +2,16 @@
   "permissions": {
     "allow": [
       "Bash(ruff:*)",
+      "Bash(pytest:*)",
       "Bash(pyright:*)",
       "Bash(mkdocs:*)",
       "Bash(rg:*)",
       "Bash(ls:*)",
       "Bash(grep:*)",
       "Bash(find:*)",
-      "Bash(mkdir:*)"
+      "Bash(mkdir:*)",
+      "Bash(python:*)",
+      "Bash(uv:*)"
     ],
     "deny": []
   }


### PR DESCRIPTION
## Summary

Add essential Python development tools to Claude's allowed Bash commands configuration.

## Changes

- Added `pytest` for running Python tests
- Added `python` for direct Python interpreter execution  
- Added `uv` for Python package management

## Context

These additions enable Claude to perform common development tasks directly within the development environment, improving workflow efficiency for Python SDK development.