### PR TITLE
chore: ignore Dream local state and bump to 0.22.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ pyrightconfig.json
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode
+
+# Dream plugin local state (baseline, findings ledger, run logs)
+.claude/dream/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bloomy-python"
-version = "0.22.0"
+version = "0.22.1"
 description = "Python SDK for Bloom Growth API"
 readme = "README.md"
 authors = [{ name = "Franccesco Orozco", email = "franccesco@codingdose.info" }]

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bloomy-python"
-version = "0.21.2"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "bloomy-python"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Keep Dream plugin local state out of the repository and sync packaging metadata after the 0.22.0 release.

## Why

- The Dream plugin writes baseline, findings, and run logs under `.claude/dream/`. That data is machine-local and must not be committed.
- `uv.lock` still listed package version `0.21.2` while `pyproject.toml` was already at `0.22.0` on main. The lockfile needed a sync.

## What changed

- **`.gitignore`**: ignore `.claude/dream/`
- **`uv.lock`**: set `bloomy-python` package version to match the project version
- **`pyproject.toml` + `uv.lock`**: patch bump to **0.22.1**

## Test plan

- [x] Confirmed only intended files are in the commits
- [x] Confirmed `.claude/dream/` is ignored and not tracked
- [x] Confirmed package version is `0.22.1` in `pyproject.toml` and `uv.lock`