### PR TITLE
dream: replace pydantic populate_by_name with validate_by_name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "httpx>=0.27.0",
   "pyyaml>=6.0",
   "typing-extensions>=4.0.0",
-  "pydantic>=2.0.0",
+  "pydantic>=2.11.0",
 ]
 
 [project.optional-dependencies]

--- a/src/bloomy/models.py
+++ b/src/bloomy/models.py
@@ -52,7 +52,8 @@ class BloomyBaseModel(BaseModel):
     """Base model with common configuration for all Bloomy models."""
 
     model_config = ConfigDict(
-        populate_by_name=True,
+        validate_by_name=True,
+        validate_by_alias=True,
         use_enum_values=True,
         validate_assignment=True,
         arbitrary_types_allowed=True,

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ dev = [
 requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },


### PR DESCRIPTION
## Dream finding

- **Dream:** dream-2026-07-23.1
- **Umbrella:** https://github.com/franccesco/bloomy-python/issues/20
- **Finding:** `001` — pydantic `populate_by_name` → `validate_by_name` + `validate_by_alias`
- **Ledger:** `.claude/dream/findings/001-populate-by-name.md`

## Why

Pydantic 2.11 docs mark `populate_by_name` as not recommended (deprecated in v3). The equivalent pair is `validate_by_name=True` with `validate_by_alias=True`. Floor raised to `pydantic>=2.11.0`.

## Proof

Verifier applied patch; unit tests + basedpyright clean.

Nothing auto-merges — human review required.
