### PR TITLE
dream: upgrade mkdocs-material to 9.7.7 (search.suggest XSS)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,6 @@ markers = [
 [dependency-groups]
 dev = [
   "mkdocs>=1.6.1",
-  "mkdocs-material>=9.6.14",
+  "mkdocs-material>=9.7.7",
   "mkdocstrings[python]>=0.29.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ provides-extras = ["dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
-    { name = "mkdocs-material", specifier = ">=9.6.14" },
+    { name = "mkdocs-material", specifier = ">=9.7.7" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
 ]
 
@@ -415,7 +415,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.6.14"
+version = "9.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -430,9 +430,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/fa/0101de32af88f87cf5cc23ad5f2e2030d00995f74e616306513431b8ab4b/mkdocs_material-9.6.14.tar.gz", hash = "sha256:39d795e90dce6b531387c255bd07e866e027828b7346d3eba5ac3de265053754", size = 3951707, upload-time = "2025-05-13T13:27:57.173Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/a1/7fdb959ad592e013c01558822fd3c22931a95a0f08cf0a7c36da13a5b2b5/mkdocs_material-9.6.14-py3-none-any.whl", hash = "sha256:3b9cee6d3688551bf7a8e8f41afda97a3c39a12f0325436d76c86706114b721b", size = 8703767, upload-time = "2025-05-13T13:27:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Dream finding

- **Dream:** dream-2026-07-23.1
- **Umbrella:** https://github.com/franccesco/bloomy-python/issues/20
- **Finding:** `003` — mkdocs-material DOM XSS GHSA-xvg9-69gf-fjrf
- **Ledger:** `.claude/dream/findings/003-material-xss.md`

## Why

`search.suggest` is enabled; advisory requires 9.7.7.

Nothing auto-merges — human review required.
