### PR TITLE
dream: use httpx data= for Token form encoding

### DIFF
--- a/src/bloomy/configuration.py
+++ b/src/bloomy/configuration.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import urlencode
 
 import httpx
 import yaml
@@ -81,14 +80,11 @@ class Configuration:
         with httpx.Client() as client:
             response = client.post(
                 "https://app.bloomgrowth.com/Token",
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                content=urlencode(
-                    {
-                        "grant_type": "password",
-                        "userName": username,
-                        "password": password,
-                    }
-                ),
+                data={
+                    "grant_type": "password",
+                    "userName": username,
+                    "password": password,
+                },
             )
 
         if not response.is_success:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -69,7 +69,14 @@ class TestConfiguration:
             config.configure_api_key("user", "pass")
 
             assert config.api_key == "new-api-key"
-            mock_client.post.assert_called_once()
+            mock_client.post.assert_called_once_with(
+                "https://app.bloomgrowth.com/Token",
+                data={
+                    "grant_type": "password",
+                    "userName": "user",
+                    "password": "pass",
+                },
+            )
 
     def test_configure_api_key_failure(self):
         """Test API key configuration with authentication failure."""


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `005`
- Use httpx `data=` for Token form body instead of urlencode+content.
Nothing auto-merges.
