### PR TITLE
dream: return True after raise_for_status in score()

### DIFF
--- a/src/bloomy/operations/async_/scorecard.py
+++ b/src/bloomy/operations/async_/scorecard.py
@@ -145,4 +145,4 @@ class AsyncScorecardOperations(AsyncBaseOperations):
             json={"value": score},
         )
         response.raise_for_status()
-        return response.is_success
+        return True

--- a/src/bloomy/operations/scorecard.py
+++ b/src/bloomy/operations/scorecard.py
@@ -182,4 +182,4 @@ class ScorecardOperations(BaseOperations):
             json={"value": score},
         )
         response.raise_for_status()
-        return response.is_success
+        return True


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `006`
- `score()` returns `True` after `raise_for_status` (is_success always true on that path).
Nothing auto-merges.
