### PR TITLE
dream: use httpx params for todo complete

### DIFF
--- a/src/bloomy/operations/async_/todos.py
+++ b/src/bloomy/operations/async_/todos.py
@@ -145,7 +145,9 @@ class AsyncTodoOperations(AsyncBaseOperations, TodoOperationsMixin):
             ```
 
         """
-        response = await self._client.post(f"todo/{todo_id}/complete?status=true")
+        response = await self._client.post(
+            f"todo/{todo_id}/complete", params={"status": True}
+        )
         response.raise_for_status()
         return await self.details(todo_id)
 

--- a/src/bloomy/operations/todos.py
+++ b/src/bloomy/operations/todos.py
@@ -145,7 +145,9 @@ class TodoOperations(BaseOperations, TodoOperationsMixin):
             ```
 
         """
-        response = self._client.post(f"todo/{todo_id}/complete?status=true")
+        response = self._client.post(
+            f"todo/{todo_id}/complete", params={"status": True}
+        )
         response.raise_for_status()
         return self.details(todo_id)
 

--- a/tests/test_async_todos.py
+++ b/tests/test_async_todos.py
@@ -274,7 +274,9 @@ class TestAsyncTodoOperations:
         assert result.complete is True
 
         # Verify the API calls
-        mock_async_client.post.assert_called_once_with("todo/1/complete?status=true")
+        mock_async_client.post.assert_called_once_with(
+            "todo/1/complete", params={"status": True}
+        )
         mock_async_client.get.assert_called_once_with("todo/1")
 
     @pytest.mark.asyncio

--- a/tests/test_todos.py
+++ b/tests/test_todos.py
@@ -116,7 +116,9 @@ class TestTodoOperations:
 
         assert result.id == 789
         assert result.complete is True
-        mock_http_client.post.assert_called_once_with("todo/789/complete?status=true")
+        mock_http_client.post.assert_called_once_with(
+            "todo/789/complete", params={"status": True}
+        )
         mock_http_client.get.assert_called_once_with("todo/789")
 
     def test_update_todo(self, mock_http_client: Mock) -> None:


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `007`
- Todo complete uses `params=` instead of embedded query string.
Nothing auto-merges.
