### PR TITLE
dream: annotate client context managers with Self

### DIFF
--- a/src/bloomy/async_client.py
+++ b/src/bloomy/async_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 import httpx
 
@@ -112,7 +112,7 @@ class AsyncClient:
             self._client
         )
 
-    async def __aenter__(self) -> AsyncClient:
+    async def __aenter__(self) -> Self:
         """Enter the async context manager.
 
         Returns:

--- a/src/bloomy/client.py
+++ b/src/bloomy/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 import httpx
 
@@ -92,7 +92,7 @@ class Client:
         self.issue = IssueOperations(self._client)
         self.headline = HeadlineOperations(self._client)
 
-    def __enter__(self) -> Client:
+    def __enter__(self) -> Self:
         """Context manager entry.
 
         Returns:


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `008`
- Annotate `__enter__`/`__aenter__` with `typing.Self`.
Nothing auto-merges.
