### PR TITLE
dream: set asyncio_default_fixture_loop_scope=function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ reportMissingImports = true
 testpaths = ["tests"]
 pythonpath = ["src"]
 addopts = "-ra --strict-markers --cov=bloomy --cov-report=term-missing"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
   "integration: marks tests that hit the real Bloom Growth API (deselect with '-m \"not integration\"')",
 ]


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `009`
- Silence pytest-asyncio deprecation by setting `asyncio_default_fixture_loop_scope = "function"`.
Nothing auto-merges.
