### PR TITLE
dream: remove unused Ruff FAST (FastAPI) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ select = [
   "SIM",   # simplify — call out over-engineered constructs; prefer the obvious one-liner.
   "N",     # pep8-naming — enforce PEP 8 names for classes, funcs, vars, etc.
   "RUF",   # Ruff-native extras — Ruff-only correctness/perf rules (a la "unicorn").
-  "FAST",  # fastapi — idiomatic FastAPI patterns and anti-pattern detection.
   "DOC",   # pydoclint — Google/Numpy docstring section order & completeness.
   "D",     # pydocstyle — PEP 257 docstring formatting conformance.
   "ARG",   # unused-arguments — catch never-used *args/**kwargs/params.


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `010`
- Remove FastAPI-only Ruff FAST select from this httpx SDK.
Nothing auto-merges.
