### PR TITLE
dream: type bulk sync create_func as Callable

### DIFF
--- a/src/bloomy/utils/abstract_operations.py
+++ b/src/bloomy/utils/abstract_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from ..models import BulkCreateError, BulkCreateResult
@@ -70,7 +71,7 @@ class AbstractOperations:
     def _process_bulk_sync[T](
         self,
         items: list[dict[str, Any]],
-        create_func: Any,
+        create_func: Callable[[dict[str, Any]], T],
         required_fields: list[str],
     ) -> BulkCreateResult[T]:
         """Process bulk creation synchronously.

--- a/tests/test_abstract_operations.py
+++ b/tests/test_abstract_operations.py
@@ -85,3 +85,26 @@ class TestAbstractOperations:
         # Test with all None values
         params = ops._prepare_params(a=None, b=None)
         assert params == {}
+
+    def test_process_bulk_sync_create_func_signature(self) -> None:
+        """_process_bulk_sync accepts Callable[[dict[str, Any]], T] create_func."""
+        client = MockHTTPClient()
+        ops = ConcreteOperations(client)
+
+        def create_func(item_data: dict) -> str:
+            return f"created-{item_data['title']}"
+
+        result = ops._process_bulk_sync(
+            [
+                {"title": "a"},
+                {"title": "b"},
+                {},  # missing required field
+            ],
+            create_func,
+            required_fields=["title"],
+        )
+
+        assert result.successful == ["created-a", "created-b"]
+        assert len(result.failed) == 1
+        assert result.failed[0].index == 2
+        assert "title" in result.failed[0].error


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `012`
- Type `_process_bulk_sync` create_func as Callable.
Nothing auto-merges.
