### PR TITLE
dream: export BulkCreateResult and BulkCreateError

### DIFF
--- a/src/bloomy/__init__.py
+++ b/src/bloomy/__init__.py
@@ -8,6 +8,8 @@ from .configuration import Configuration
 from .exceptions import APIError, AuthenticationError, BloomyError, ConfigurationError
 from .models import (
     ArchivedGoalInfo,
+    BulkCreateError,
+    BulkCreateResult,
     CreatedGoalInfo,
     CreatedIssue,
     CurrentWeek,
@@ -49,6 +51,8 @@ __all__ = [
     "AsyncClient",
     "AuthenticationError",
     "BloomyError",
+    "BulkCreateError",
+    "BulkCreateResult",
     "Client",
     "Configuration",
     "ConfigurationError",


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `013`
- Export BulkCreateResult/BulkCreateError from package root.
Nothing auto-merges.
