### PR TITLE
dream: PEP 695 type aliases for pydantic Annotated types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
   "httpx>=0.27.0",
   "pyyaml>=6.0",
-  "pydantic>=2.0.0",
+  "pydantic>=2.11.0",
 ]
 
 [project.optional-dependencies]

--- a/src/bloomy/models.py
+++ b/src/bloomy/models.py
@@ -33,11 +33,14 @@ def _parse_optional_float(v: Any) -> float | None:
     return float(v)
 
 
-# Reusable annotated types for optional fields that may come as empty strings
-OptionalDatetime = Annotated[datetime | None, BeforeValidator(_parse_optional_datetime)]
-OptionalFloat = Annotated[float | None, BeforeValidator(_parse_optional_float)]
+# Reusable annotated types for optional fields that may come as empty strings.
+# PEP 695 named aliases (requires pydantic>=2.11 for full support).
+type OptionalDatetime = Annotated[
+    datetime | None, BeforeValidator(_parse_optional_datetime)
+]
+type OptionalFloat = Annotated[float | None, BeforeValidator(_parse_optional_float)]
 # Coerces a nullable value (e.g. a datetime or None) into a bool (present = True)
-IsPresent = Annotated[bool, BeforeValidator(lambda v: v is not None and v != "")]
+type IsPresent = Annotated[bool, BeforeValidator(lambda v: v is not None and v != "")]
 
 
 class GoalStatus(StrEnum):
@@ -371,7 +374,8 @@ class HeadlineDetails(BloomyBaseModel):
     closed_at: str | None = None
 
 
-# HeadlineListItem is identical to HeadlineDetails - use type alias
+# HeadlineListItem is identical to HeadlineDetails - use assignment alias so the
+# name remains callable (PEP 695 `type` produces a non-callable TypeAliasType).
 HeadlineListItem = HeadlineDetails
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ dev = [
 requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },


### PR DESCRIPTION
## Dream finding
- **Dream:** dream-2026-07-23.1 | **Umbrella:** #20 | **Finding:** `015`
- Use PEP 695 `type` for Annotated aliases; keep HeadlineListItem assignment form; pydantic>=2.11.
Nothing auto-merges.
