### PR TITLE
chore: restore pytest and mkdocs-material lower bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "pytest>=8.0.0",
+  "pytest>=9.0.3",
   "pytest-cov>=5.0.0",
   "pytest-asyncio>=0.23.0",
   "ruff>=0.5.0",
@@ -85,6 +85,6 @@ markers = [
 [dependency-groups]
 dev = [
   "mkdocs>=1.6.1",
-  "mkdocs-material>=9.6.14",
+  "mkdocs-material>=9.7.7",
   "mkdocstrings[python]>=0.29.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -101,7 +101,7 @@ provides-extras = ["dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
-    { name = "mkdocs-material", specifier = ">=9.6.14" },
+    { name = "mkdocs-material", specifier = ">=9.7.7" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
 ]
 


### PR DESCRIPTION
## Why
During sequential merge of dream PRs, a pyproject conflict resolver rewrote floors back to older lower bounds while the lockfile kept pytest 9.1.1 and mkdocs-material 9.7.7.

## Change
- `pytest>=9.0.3` (GHSA-6w46-j5rx-g56g)
- `mkdocs-material>=9.7.7` (GHSA-xvg9-69gf-fjrf)

No runtime behavior change beyond re-asserting the security floors.