### PR TITLE
fix: null scorecard target + live integration meeting id

### DIFF
--- a/src/bloomy/models.py
+++ b/src/bloomy/models.py
@@ -293,7 +293,7 @@ class ScorecardItem(BloomyBaseModel):
     measurable_id: int
     accountable_user_id: int
     title: str
-    target: float
+    target: OptionalFloat = None  # API may return null Target for unset goals
     value: float | None = None
     week: str  # Changed from int to str to handle "2024-W25" format
     week_id: int

--- a/tests/test_integration_goals.py
+++ b/tests/test_integration_goals.py
@@ -14,7 +14,7 @@ from bloomy.models import (
     GoalStatus,
 )
 
-MEETING_ID = 324926
+MEETING_ID = 327249  # Scorecard Test Meeting (was 324926, access revoked)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_integration_headlines.py
+++ b/tests/test_integration_headlines.py
@@ -11,7 +11,7 @@ import pytest_asyncio
 from bloomy import AsyncClient, Client
 from bloomy.models import HeadlineDetails, HeadlineInfo, HeadlineListItem
 
-MEETING_ID = 324926
+MEETING_ID = 327249  # Scorecard Test Meeting (was 324926, access revoked)
 
 pytestmark = pytest.mark.integration
 

--- a/tests/test_integration_issues.py
+++ b/tests/test_integration_issues.py
@@ -11,7 +11,7 @@ import pytest_asyncio
 from bloomy import AsyncClient, Client
 from bloomy.models import CreatedIssue, IssueDetails, IssueListItem
 
-MEETING_ID = 324926
+MEETING_ID = 327249  # Scorecard Test Meeting (was 324926, access revoked)
 
 pytestmark = pytest.mark.integration
 

--- a/tests/test_integration_todos.py
+++ b/tests/test_integration_todos.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 from bloomy import AsyncClient, Client
 from bloomy.models import Todo
 
-MEETING_ID = 324926
+MEETING_ID = 327249  # Scorecard Test Meeting (was 324926, access revoked)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Why
Post-dream e2e against the real API failed because:

1. `ScorecardItem.target` was required `float` but the API returns `null` for unset targets.
2. Integration fixtures used meeting `324926`, which returns \"Cannot view this Weekly Meeting\" for the current account.

## Changes
- Make `ScorecardItem.target` optional (`OptionalFloat`).
- Point integration tests at meeting `327249` (Scorecard Test Meeting).

## Test plan
- Unit scorecard tests
- `pytest -m integration` with refreshed API key