### PR TITLE
chore: ignore .grok local state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ pyrightconfig.json
 
 # Dream plugin local state (baseline, findings ledger, run logs)
 .claude/dream/
+
+# Grok CLI local state
+.grok/


### PR DESCRIPTION
## Summary

Adds `.grok/` to `.gitignore`. This directory holds local Grok CLI state and must not go into version control.

## Test plan

- [x] `git status` no longer shows `.grok/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)